### PR TITLE
Feat/image svg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,10 +30,23 @@ dependencies = [
  "objc2-app-kit",
  "objc2-foundation",
  "parking_lot",
- "windows-sys",
+ "resvg",
+ "windows-sys 0.48.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "atty"
@@ -53,6 +66,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,9 +79,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block2"
@@ -74,16 +93,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytecount"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
-
-[[package]]
 name = "bytemuck"
-version = "1.12.1"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
 
 [[package]]
 name = "byteorder"
@@ -111,6 +124,12 @@ checksum = "79f4473f5144e20d9aceaf2972478f06ddf687831eafeeb434fbaf0acc4144ad"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "core-foundation"
@@ -162,15 +181,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive-new"
-version = "0.5.9"
+name = "data-url"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.100",
-]
+checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
 name = "dlib"
@@ -202,23 +216,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -250,10 +253,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a595cb550439a117696039dfc69830492058211b771a2a165379f2a1a53d84d"
+dependencies = [
+ "roxmltree 0.19.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32eac81c1135c1df01d4e6d4233c47ba11f6a6d07f33e0bba09d18797077770"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -289,7 +321,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
 dependencies = [
  "libc",
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "gif"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -305,6 +347,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -327,6 +378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,16 +400,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
+name = "kurbo"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "6e5aa9f0f96a938266bdb12928a67169e8d22c6a786fda8ed984b85e6ba93c3c"
+dependencies = [
+ "arrayvec",
+ "smallvec",
+]
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
@@ -361,14 +422,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.8"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -382,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
@@ -393,12 +454,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "memoffset"
-version = "0.7.1"
+name = "memmap2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
- "autocfg",
+ "libc",
 ]
 
 [[package]]
@@ -414,19 +475,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset",
- "pin-utils",
 ]
 
 [[package]]
@@ -511,12 +559,12 @@ checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "os_pipe"
-version = "1.1.4"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae859aa07428ca9a929b936690f8b12dc5f11dd8c6992a18ca93919f28bc177"
+checksum = "29d73ba8daf8fac13b0501d1abeddcfe21ba7401ada61a819144b6c2a4f32209"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -539,7 +587,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -553,10 +601,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
+name = "pico-args"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pkg-config"
@@ -587,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "memchr",
 ]
@@ -630,16 +678,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
-name = "rustix"
-version = "0.38.17"
+name = "resvg"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25469e9ae0f3d0047ca8b93fc56843f38e6774f0914a107ff8b41be8be8e0b7"
+checksum = "944d052815156ac8fa77eaac055220e95ba0b01fa8887108ca710c03805d9051"
 dependencies = [
- "bitflags 2.4.0",
+ "gif",
+ "jpeg-decoder",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7439be6844e40133eda024efd85bf07f59d0dd2f59b10c00dd6cfb92cc5c741"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustybuzz"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytemuck",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
 ]
 
 [[package]]
@@ -655,10 +756,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "smallvec"
-version = "1.9.0"
+name = "simplecss"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a11be7c62927d9427e9f40f3444d5499d868648e2edbc4e2116de69e7ec0e89d"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
+name = "svgtypes"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fae3064df9b89391c9a76a0425a69d124aee9c5c28455204709e72c39868a43c"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -684,15 +828,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -736,18 +879,83 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree_magic_mini"
-version = "3.0.3"
+name = "tiny-skia"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91adfd0607cacf6e4babdb870e9bec4037c1c4b151cfd279ccefc5e0c7feaa6d"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
 dependencies = [
- "bytecount",
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469a727cac55b41448315cc10427c069c618ac59bb6a4480283fcd811749bdc2"
+dependencies = [
  "fnv",
- "lazy_static",
+ "home",
+ "memchr",
  "nom",
  "once_cell",
  "petgraph",
 ]
+
+[[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
 
 [[package]]
 name = "unicode-ident"
@@ -756,14 +964,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
-name = "wayland-backend"
-version = "0.3.2"
+name = "unicode-properties"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19152ddd73f45f024ed4534d9ca2594e0ef252c1847695255dae47f34df9fbe4"
+checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d71f5726e5f285a935e9fe8edfd53f0491eb6e9a5774097fdabee7cd8c9cd"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
+name = "usvg"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84ea542ae85c715f07b082438a4231c3760539d902e11d093847a0b22963032"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree 0.20.0",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34e9e6b6d4a2bb4e7e69433e0b35c7923b95d4dc8503a84d25ec917a4bbfdf07"
 dependencies = [
  "cc",
  "downcast-rs",
- "nix",
+ "rustix",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -771,23 +1030,23 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca7d52347346f5473bf2f56705f360e8440873052e575e55890c4fa57843ed3"
+checksum = "1e63801c85358a431f986cffa74ba9599ff571fc5774ac113ed3b490c19a1133"
 dependencies = [
- "bitflags 2.4.0",
- "nix",
+ "bitflags 2.6.0",
+ "rustix",
  "wayland-backend",
  "wayland-scanner",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e253d7107ba913923dc253967f35e8561a3c65f914543e46843c88ddd729e21c"
+checksum = "83d0f1056570486e26a3773ec633885124d79ae03827de05ba6c85f79904026c"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -795,11 +1054,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+checksum = "a7dab47671043d9f5397035975fe1cac639e5bca5cc0b3c32d09f01612e34d24"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -808,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8e28403665c9f9513202b7e1ed71ec56fde5c107816843fb14057910b2c09c"
+checksum = "67da50b9f80159dec0ea4c11c13e24ef9e7574bd6ce24b01860a175010cea565"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -819,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af"
+checksum = "105b1842da6554f91526c14a2a2172897b7f745a805d62af4ce698706be79c12"
 dependencies = [
  "dlib",
  "log",
@@ -830,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "weezl"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "winapi"
@@ -871,7 +1130,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -880,13 +1148,29 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -896,10 +1180,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -908,10 +1204,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -920,10 +1234,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -932,16 +1258,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
-name = "wl-clipboard-rs"
-version = "0.8.0"
+name = "windows_x86_64_msvc"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57af79e973eadf08627115c73847392e6b766856ab8e3844a59245354b23d2fa"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de22eebb1d1e2bad2d970086e96da0e12cde0b411321e5b0f7b2a1f876aa26f"
 dependencies = [
- "derive-new",
  "libc",
  "log",
- "nix",
  "os_pipe",
+ "rustix",
  "tempfile",
  "thiserror",
  "tree_magic_mini",
@@ -967,3 +1298,9 @@ name = "x11rb-protocol"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,6 @@ default = ["image-data"]
 image-data = ["core-graphics", "image", "windows-sys"]
 wayland-data-control = ["wl-clipboard-rs"]
 
-[dependencies]
-
 [dev-dependencies]
 env_logger = "0.9.0"
 
@@ -29,7 +27,6 @@ windows-sys = { version = "0.48.0", optional = true, features = [
     "Win32_System_Ole",
 ]}
 clipboard-win = "5.3.1"
-log = "0.4"
 image = { version = "0.25", optional = true, default-features = false, features = ["png"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -41,7 +38,6 @@ core-graphics = { version = "0.23", optional = true }
 image = { version = "0.25", optional = true, default-features = false, features = ["tiff"] }
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
-log = "0.4"
 x11rb = { version = "0.13" }
 wl-clipboard-rs = { version = "0.9", optional = true }
 image = { version = "0.25", optional = true, default-features = false, features = ["png"] }
@@ -54,3 +50,7 @@ required-features = ["image-data"]
 [[example]]
 name = "set_image"
 required-features = ["image-data"]
+
+[dependencies]
+resvg = "0.42.0"
+log = "0.4"

--- a/examples/get_image.rs
+++ b/examples/get_image.rs
@@ -5,5 +5,14 @@ fn main() {
 
 	let img = ctx.get_image().unwrap();
 
-	println!("Image data is:\n{:?}", img.bytes);
+	match img {
+		arboard::ImageData::Rgba(img) => {
+			println!("Image width is: {}", img.width);
+			println!("Image height is: {}", img.height);
+			println!("Image data is:\n{:?}", img.bytes);
+		}
+		arboard::ImageData::Svg(svg) => {
+			println!("SVG data is:\n{}", svg);
+		}
+	}
 }

--- a/examples/set_image.rs
+++ b/examples/set_image.rs
@@ -10,6 +10,6 @@ fn main() {
 		100, 100, 255, 100,
 		0, 0, 0, 255,
 	];
-	let img_data = ImageData { width: 2, height: 2, bytes: bytes.as_ref().into() };
+	let img_data = ImageData::rgba(2, 2, bytes.as_ref().into());
 	ctx.set_image(img_data).unwrap();
 }

--- a/examples/set_svg.rs
+++ b/examples/set_svg.rs
@@ -6,7 +6,7 @@ fn main() {
 	let svg = r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<svg width="100" height="100">
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
   <circle cx="50" cy="50" r="40" stroke="black" stroke-width="2" fill="red" />
 </svg>"#;
 

--- a/examples/set_svg.rs
+++ b/examples/set_svg.rs
@@ -1,0 +1,15 @@
+use arboard::{Clipboard, ImageData};
+
+fn main() {
+	let mut ctx = Clipboard::new().unwrap();
+
+	let svg = r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg width="100" height="100">
+  <circle cx="50" cy="50" r="40" stroke="black" stroke-width="2" fill="red" />
+</svg>"#;
+
+	let img_data = ImageData::svg(svg);
+	ctx.set_image(img_data).unwrap();
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -243,7 +243,9 @@ pub(crate) fn svg2pixmap<'s>(svg: &'s str) -> Result<tiny_skia::Pixmap, usvg::Er
 	opt.fontdb_mut().load_system_fonts();
 	let tree = usvg::Tree::from_data(svg.as_bytes(), &opt)?;
 	let pixmap_size = tree.size().to_int_size();
-	let mut pixmap = tiny_skia::Pixmap::new(pixmap_size.width(), pixmap_size.height()).unwrap();
+	let Some(mut pixmap) = tiny_skia::Pixmap::new(pixmap_size.width(), pixmap_size.height()) else {
+		return Err(usvg::Error::InvalidSize);
+	};
 	resvg::render(&tree, tiny_skia::Transform::default(), &mut pixmap.as_mut());
 	Ok(pixmap)
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -96,6 +96,13 @@ impl Error {
 	}
 }
 
+#[cfg(feature = "image-data")]
+#[derive(Debug, Clone)]
+pub enum ImageData<'a> {
+	Rgba(ImageRgba<'a>),
+	Svg(String),
+}
+
 /// Stores pixel data of an image.
 ///
 /// Each element in `bytes` stores the value of a channel of a single pixel.
@@ -108,7 +115,7 @@ impl Error {
 ///
 /// Assigning a `2*1` image would for example look like this
 /// ```
-/// use arboard::ImageData;
+/// use arboard::ImageRgba;
 /// use std::borrow::Cow;
 /// let bytes = [
 ///     // A red pixel
@@ -117,7 +124,7 @@ impl Error {
 ///     // A green pixel
 ///     0, 255, 0, 255,
 /// ];
-/// let img = ImageData {
+/// let img = ImageRgba {
 ///     width: 2,
 ///     height: 1,
 ///     bytes: Cow::from(bytes.as_ref())
@@ -125,7 +132,7 @@ impl Error {
 /// ```
 #[cfg(feature = "image-data")]
 #[derive(Debug, Clone)]
-pub struct ImageData<'a> {
+pub struct ImageRgba<'a> {
 	pub width: usize,
 	pub height: usize,
 	pub bytes: Cow<'a, [u8]>,
@@ -133,6 +140,43 @@ pub struct ImageData<'a> {
 
 #[cfg(feature = "image-data")]
 impl<'a> ImageData<'a> {
+	pub fn rgba(width: usize, height: usize, bytes: Cow<'a, [u8]>) -> Self {
+		ImageData::Rgba(ImageRgba { width, height, bytes })
+	}
+
+	pub fn svg<S: Into<String>>(svg: S) -> Self {
+		ImageData::Svg(svg.into())
+	}
+
+	/// Returns a the bytes field in a way that it's guaranteed to be owned.
+	/// It moves the bytes if they are already owned and clones them if they are borrowed.
+	pub fn into_owned_bytes(self) -> Cow<'static, [u8]> {
+		match self {
+			ImageData::Rgba(p) => p.into_owned_bytes(),
+			ImageData::Svg(s) => Cow::Owned(s.into_bytes()),
+		}
+	}
+
+	/// Returns an image data that is guaranteed to own its bytes.
+	/// It moves the bytes if they are already owned and clones them if they are borrowed.
+	pub fn to_owned_img(&self) -> ImageData<'static> {
+		match self {
+			ImageData::Rgba(p) => ImageData::Rgba(p.to_owned_img()),
+			ImageData::Svg(s) => ImageData::Svg(s.clone()),
+		}
+	}
+
+	/// Returns the bytes of the image data.
+	pub fn bytes(&self) -> &[u8] {
+		match self {
+			ImageData::Rgba(p) => &p.bytes,
+			ImageData::Svg(s) => s.as_bytes(),
+		}
+	}
+}
+
+#[cfg(feature = "image-data")]
+impl<'a> ImageRgba<'a> {
 	/// Returns a the bytes field in a way that it's guaranteed to be owned.
 	/// It moves the bytes if they are already owned and clones them if they are borrowed.
 	pub fn into_owned_bytes(self) -> Cow<'static, [u8]> {
@@ -141,8 +185,8 @@ impl<'a> ImageData<'a> {
 
 	/// Returns an image data that is guaranteed to own its bytes.
 	/// It moves the bytes if they are already owned and clones them if they are borrowed.
-	pub fn to_owned_img(&self) -> ImageData<'static> {
-		ImageData {
+	pub fn to_owned_img(&self) -> ImageRgba<'static> {
+		ImageRgba {
 			width: self.width,
 			height: self.height,
 			bytes: self.bytes.clone().into_owned().into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use std::borrow::Cow;
 
 pub use common::Error;
 #[cfg(feature = "image-data")]
-pub use common::ImageData;
+pub use common::{ImageData, ImageRgba};
 
 mod platform;
 
@@ -329,7 +329,7 @@ mod tests {
 				100, 100, 255, 100,
 				0, 0, 0, 255,
 			];
-			let img_data = ImageData { width: 2, height: 2, bytes: bytes.as_ref().into() };
+			let img_data = ImageData::rgba(2, 2, Cow::from(bytes.as_ref()));
 
 			// Make sure that setting one format overwrites the other.
 			ctx.set_image(img_data.clone()).unwrap();
@@ -341,7 +341,7 @@ mod tests {
 			// Test if we get the same image that we put onto the clipboard
 			ctx.set_image(img_data.clone()).unwrap();
 			let got = ctx.get_image().unwrap();
-			assert_eq!(img_data.bytes, got.bytes);
+			assert_eq!(img_data.bytes(), got.bytes());
 
 			#[rustfmt::skip]
 			let big_bytes = vec![
@@ -354,10 +354,10 @@ mod tests {
 				0, 1, 2, 255,
 			];
 			let bytes_cloned = big_bytes.clone();
-			let big_img_data = ImageData { width: 3, height: 2, bytes: big_bytes.into() };
+			let big_img_data = ImageData::rgba(3, 2, Cow::from(bytes.as_ref()));
 			ctx.set_image(big_img_data).unwrap();
 			let got = ctx.get_image().unwrap();
-			assert_eq!(bytes_cloned.as_slice(), got.bytes.as_ref());
+			assert_eq!(bytes_cloned.as_slice(), got.bytes().as_ref());
 		}
 		#[cfg(all(
 			unix,

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -3,9 +3,9 @@ use std::{borrow::Cow, time::Instant};
 #[cfg(feature = "wayland-data-control")]
 use log::{trace, warn};
 
-#[cfg(feature = "image-data")]
-use crate::ImageData;
 use crate::{common::private, Error};
+#[cfg(feature = "image-data")]
+use crate::{ImageData, ImageRgba};
 
 mod x11;
 
@@ -17,7 +17,7 @@ fn into_unknown<E: std::fmt::Display>(error: E) -> Error {
 }
 
 #[cfg(feature = "image-data")]
-fn encode_as_png(image: &ImageData) -> Result<Vec<u8>, Error> {
+fn encode_as_png(image: &ImageRgba) -> Result<Vec<u8>, Error> {
 	use image::ImageEncoder as _;
 
 	if image.bytes.is_empty() || image.width == 0 || image.height == 0 {

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -141,7 +141,7 @@ impl GetExtLinux for crate::Get<'_> {
 }
 
 /// Configuration on how long to wait for a new X11 copy event is emitted.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub(crate) enum WaitConfig {
 	/// Waits until the given [`Instant`] has reached.
 	Until(Instant),
@@ -184,7 +184,7 @@ impl<'clipboard> Set<'clipboard> {
 	}
 
 	#[cfg(feature = "image-data")]
-	pub(crate) fn image(self, image: ImageData<'_>) -> Result<(), Error> {
+	pub(crate) fn image(self, image: ImageData<'_>, _clear: bool) -> Result<(), Error> {
 		match self.clipboard {
 			Clipboard::X11(clipboard) => clipboard.set_image(image, self.selection, self.wait),
 

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -234,8 +234,7 @@ impl Clipboard {
 		let mut opts = Options::new();
 		opts.foreground(matches!(wait, WaitConfig::Forever));
 		opts.clipboard(selection.try_into()?);
-		let source = Source::Bytes(svg.into_bytes().into_boxed_slice());
-		opts.copy(source, MimeType::Specific(MIME_SVG.into())).map_err(into_unknown)?;
-		Ok(())
+		let source = Source::Bytes(svg.clone().into_bytes().into_boxed_slice());
+		opts.copy(source, MimeType::Specific(MIME_SVG.into())).map_err(into_unknown)
 	}
 }

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -12,10 +12,12 @@ use super::encode_as_png;
 use super::{into_unknown, LinuxClipboardKind, WaitConfig};
 use crate::common::Error;
 #[cfg(feature = "image-data")]
-use crate::common::ImageData;
+use crate::common::{ImageData, ImageRgba};
 
 #[cfg(feature = "image-data")]
 const MIME_PNG: &str = "image/png";
+#[cfg(feature = "image-data")]
+const MIME_SVG: &str = "image/svg+xml";
 
 pub(crate) struct Clipboard {}
 
@@ -126,6 +128,17 @@ impl Clipboard {
 		&mut self,
 		selection: LinuxClipboardKind,
 	) -> Result<ImageData<'static>, Error> {
+		match self.get_image_svg(selection) {
+			Err(Error::ContentNotAvailable) => self.get_image_png(selection),
+			result => result,
+		}
+	}
+
+	#[cfg(feature = "image-data")]
+	pub(crate) fn get_image_png(
+		&mut self,
+		selection: LinuxClipboardKind,
+	) -> Result<ImageData<'static>, Error> {
 		use std::io::Cursor;
 		use wl_clipboard_rs::paste::MimeType;
 
@@ -142,11 +155,36 @@ impl Clipboard {
 					.map_err(|_| Error::ConversionFailure)?;
 				let image = image.into_rgba8();
 
-				Ok(ImageData {
-					width: image.width() as usize,
-					height: image.height() as usize,
-					bytes: image.into_raw().into(),
-				})
+				Ok(ImageData::rgba(
+					image.width() as usize,
+					image.height() as usize,
+					image.into_raw().into(),
+				))
+			}
+
+			Err(PasteError::ClipboardEmpty) | Err(PasteError::NoMimeType) => {
+				Err(Error::ContentNotAvailable)
+			}
+
+			Err(err) => Err(Error::Unknown { description: err.to_string() }),
+		}
+	}
+
+	#[cfg(feature = "image-data")]
+	pub(crate) fn get_image_svg(
+		&mut self,
+		selection: LinuxClipboardKind,
+	) -> Result<ImageData<'static>, Error> {
+		use std::io::Cursor;
+		use wl_clipboard_rs::paste::MimeType;
+
+		let result =
+			get_contents(selection.try_into()?, Seat::Unspecified, MimeType::Specific(MIME_SVG));
+		match result {
+			Ok((mut pipe, _mime_type)) => {
+				let mut buffer = vec![];
+				pipe.read_to_end(&mut buffer).map_err(into_unknown)?;
+				Ok(ImageData::svg(String::from_utf8(buffer).map_err(|_| Error::ConversionFailure)?))
 			}
 
 			Err(PasteError::ClipboardEmpty) | Err(PasteError::NoMimeType) => {
@@ -164,12 +202,40 @@ impl Clipboard {
 		selection: LinuxClipboardKind,
 		wait: WaitConfig,
 	) -> Result<(), Error> {
+		match image {
+			ImageData::Rgba(image) => self.set_image_png(image, selection, wait),
+			ImageData::Svg(svg) => self.set_image_svg(svg, selection, wait),
+		}
+	}
+
+	#[cfg(feature = "image-data")]
+	pub(crate) fn set_image_png(
+		&mut self,
+		image: ImageRgba,
+		selection: LinuxClipboardKind,
+		wait: WaitConfig,
+	) -> Result<(), Error> {
 		let image = encode_as_png(&image)?;
 		let mut opts = Options::new();
 		opts.foreground(matches!(wait, WaitConfig::Forever));
 		opts.clipboard(selection.try_into()?);
 		let source = Source::Bytes(image.into());
 		opts.copy(source, MimeType::Specific(MIME_PNG.into())).map_err(into_unknown)?;
+		Ok(())
+	}
+
+	#[cfg(feature = "image-data")]
+	pub(crate) fn set_image_svg(
+		&mut self,
+		svg: String,
+		selection: LinuxClipboardKind,
+		wait: WaitConfig,
+	) -> Result<(), Error> {
+		let mut opts = Options::new();
+		opts.foreground(matches!(wait, WaitConfig::Forever));
+		opts.clipboard(selection.try_into()?);
+		let source = Source::Bytes(svg.into_bytes().into_boxed_slice());
+		opts.copy(source, MimeType::Specific(MIME_SVG.into())).map_err(into_unknown)?;
 		Ok(())
 	}
 }

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -46,9 +46,9 @@ use x11rb::{
 #[cfg(feature = "image-data")]
 use super::encode_as_png;
 use super::{into_unknown, LinuxClipboardKind, WaitConfig};
-#[cfg(feature = "image-data")]
-use crate::ImageData;
 use crate::{common::ScopeGuard, Error};
+#[cfg(feature = "image-data")]
+use crate::{ImageData, ImageRgba};
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -80,6 +80,8 @@ x11rb::atom_manager! {
 		HTML: b"text/html",
 
 		PNG_MIME: b"image/png",
+
+		SVG_MIME: b"image/svg+xml",
 
 		// This is just some random name for the property on our window, into which
 		// the clipboard owner writes the data we requested.
@@ -909,6 +911,20 @@ impl Clipboard {
 
 	#[cfg(feature = "image-data")]
 	pub(crate) fn get_image(&self, selection: LinuxClipboardKind) -> Result<ImageData<'static>> {
+		let formats = [self.inner.atoms.SVG_MIME, self.inner.atoms.PNG_MIME];
+		let result = self.inner.read(&formats, selection)?;
+		match result.format {
+			atom if atom == self.inner.atoms.SVG_MIME => self.get_image_svg(selection),
+			atom if atom == self.inner.atoms.PNG_MIME => self.get_image_png(selection),
+			_ => Err(Error::ContentNotAvailable),
+		}
+	}
+
+	#[cfg(feature = "image-data")]
+	pub(crate) fn get_image_png(
+		&self,
+		selection: LinuxClipboardKind,
+	) -> Result<ImageData<'static>> {
 		let formats = [self.inner.atoms.PNG_MIME];
 		let bytes = self.inner.read(&formats, selection)?.bytes;
 
@@ -920,9 +936,19 @@ impl Clipboard {
 			Err(_e) => return Err(Error::ConversionFailure),
 		};
 		let (w, h) = image.dimensions();
-		let image_data =
-			ImageData { width: w as usize, height: h as usize, bytes: image.into_raw().into() };
+		let image_data = ImageData::rgba(w as _, h as _, image.into_raw().into());
 		Ok(image_data)
+	}
+
+	#[cfg(feature = "image-data")]
+	pub(crate) fn get_image_svg(
+		&self,
+		selection: LinuxClipboardKind,
+	) -> Result<ImageData<'static>> {
+		let formats = [self.inner.atoms.SVG_MIME];
+		let bytes = self.inner.read(&formats, selection)?.bytes;
+		let svg = String::from_utf8(bytes).map_err(|_| Error::ConversionFailure)?;
+		Ok(ImageData::svg(svg))
 	}
 
 	#[cfg(feature = "image-data")]
@@ -932,8 +958,33 @@ impl Clipboard {
 		selection: LinuxClipboardKind,
 		wait: WaitConfig,
 	) -> Result<()> {
+		match image {
+			ImageData::Rgba(data) => self.set_image_png(data, selection, wait),
+			ImageData::Svg(svg) => self.set_image_svg(svg, selection, wait),
+		}
+	}
+
+	#[cfg(feature = "image-data")]
+	pub(crate) fn set_image_png(
+		&self,
+		image: ImageRgba,
+		selection: LinuxClipboardKind,
+		wait: WaitConfig,
+	) -> Result<()> {
 		let encoded = encode_as_png(&image)?;
 		let data = vec![ClipboardData { bytes: encoded, format: self.inner.atoms.PNG_MIME }];
+		self.inner.write(data, selection, wait)
+	}
+
+	#[cfg(feature = "image-data")]
+	pub(crate) fn set_image_svg(
+		&self,
+		svg: String,
+		selection: LinuxClipboardKind,
+		wait: WaitConfig,
+	) -> Result<()> {
+		let data =
+			vec![ClipboardData { bytes: svg.into_bytes(), format: self.inner.atoms.SVG_MIME }];
 		self.inner.write(data, selection, wait)
 	}
 }

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -983,9 +983,11 @@ impl Clipboard {
 		selection: LinuxClipboardKind,
 		wait: WaitConfig,
 	) -> Result<()> {
-		let data =
-			vec![ClipboardData { bytes: svg.into_bytes(), format: self.inner.atoms.SVG_MIME }];
-		self.inner.write(data, selection, wait)
+		let data = vec![ClipboardData {
+			bytes: svg.clone().into_bytes(),
+			format: self.inner.atoms.SVG_MIME,
+		}];
+		self.inner.write(data, selection, wait.clone())
 	}
 }
 

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -304,20 +304,22 @@ impl<'clipboard> Set<'clipboard> {
 	}
 
 	#[cfg(feature = "image-data")]
-	pub(crate) fn image(self, data: ImageData) -> Result<(), Error> {
+	pub(crate) fn image(self, data: ImageData, clear: bool) -> Result<(), Error> {
 		match data {
-			ImageData::Rgba(data) => self.image_pixels(data),
-			ImageData::Svg(data) => self.image_svg(data),
+			ImageData::Rgba(data) => self.image_pixels(data, clear),
+			ImageData::Svg(data) => self.image_svg(data, clear),
 		}
 	}
 
 	#[cfg(feature = "image-data")]
-	pub(crate) fn image_pixels(self, data: ImageRgba) -> Result<(), Error> {
+	pub(crate) fn image_pixels(self, data: ImageRgba, clear: bool) -> Result<(), Error> {
 		let pixels = data.bytes.into();
 		let image = image_from_pixels(pixels, data.width, data.height)
 			.map_err(|_| Error::ConversionFailure)?;
 
-		self.clipboard.clear();
+		if clear {
+			self.clipboard.clear();
+		}
 
 		let image_array = NSArray::from_vec(vec![ProtocolObject::from_id(image)]);
 		let success = unsafe { self.clipboard.pasteboard.writeObjects(&image_array) };
@@ -333,8 +335,10 @@ impl<'clipboard> Set<'clipboard> {
 	}
 
 	#[cfg(feature = "image-data")]
-	pub(crate) fn image_svg(self, data: String) -> Result<(), Error> {
-		self.clipboard.clear();
+	pub(crate) fn image_svg(self, data: String, clear: bool) -> Result<(), Error> {
+		if clear {
+			self.clipboard.clear();
+		}
 
 		let svg = NSString::from_str(&data);
 		let success = unsafe {

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -10,7 +10,7 @@ and conditions of the chosen license apply to this file.
 
 use crate::common::Error;
 #[cfg(feature = "image-data")]
-use crate::common::ImageData;
+use crate::common::{ImageData, ImageRgba};
 use objc2::{
 	msg_send_id,
 	rc::{autoreleasepool, Id},
@@ -23,6 +23,8 @@ use std::{
 	borrow::Cow,
 	panic::{RefUnwindSafe, UnwindSafe},
 };
+
+const NS_PASTEBOARD_TYPE_SVG: &str = "public.svg-image";
 
 /// Returns an NSImage object on success.
 #[cfg(feature = "image-data")]
@@ -207,6 +209,14 @@ impl<'clipboard> Get<'clipboard> {
 
 	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self) -> Result<ImageData<'static>, Error> {
+		match self.image_svg() {
+			Err(Error::ContentNotAvailable) => self.image_tiff(),
+			result => result,
+		}
+	}
+
+	#[cfg(feature = "image-data")]
+	fn image_tiff(&self) -> Result<ImageData<'static>, Error> {
 		use objc2_app_kit::NSPasteboardTypeTIFF;
 		use std::io::Cursor;
 
@@ -225,10 +235,17 @@ impl<'clipboard> Get<'clipboard> {
 		let rgba = image.into_rgba8();
 		let (width, height) = rgba.dimensions();
 
-		Ok(ImageData {
-			width: width as usize,
-			height: height as usize,
-			bytes: rgba.into_raw().into(),
+		Ok(ImageData::rgba(width as _, height as _, rgba.into_raw().into()))
+	}
+
+	#[cfg(feature = "image-data")]
+	fn image_svg(&self) -> Result<ImageData<'static>, Error> {
+		autoreleasepool(|_| {
+			let image_data = unsafe {
+				self.clipboard.pasteboard.stringForType(&NSString::from_str(NS_PASTEBOARD_TYPE_SVG))
+			}
+			.ok_or(Error::ContentNotAvailable)?;
+			Ok(ImageData::Svg(image_data.to_string()))
 		})
 	}
 }
@@ -288,6 +305,14 @@ impl<'clipboard> Set<'clipboard> {
 
 	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self, data: ImageData) -> Result<(), Error> {
+		match data {
+			ImageData::Rgba(data) => self.image_pixels(data),
+			ImageData::Svg(data) => self.image_svg(data),
+		}
+	}
+
+	#[cfg(feature = "image-data")]
+	pub(crate) fn image_pixels(self, data: ImageRgba) -> Result<(), Error> {
 		let pixels = data.bytes.into();
 		let image = image_from_pixels(pixels, data.width, data.height)
 			.map_err(|_| Error::ConversionFailure)?;
@@ -303,6 +328,25 @@ impl<'clipboard> Set<'clipboard> {
 				description:
 					"Failed to write the image to the pasteboard (`writeObjects` returned NO)."
 						.into(),
+			})
+		}
+	}
+
+	#[cfg(feature = "image-data")]
+	pub(crate) fn image_svg(self, data: String) -> Result<(), Error> {
+		self.clipboard.clear();
+
+		let svg = NSString::from_str(&data);
+		let success = unsafe {
+			self.clipboard
+				.pasteboard
+				.setString_forType(&svg, &NSString::from_str(NS_PASTEBOARD_TYPE_SVG))
+		};
+		if success {
+			Ok(())
+		} else {
+			Err(Error::Unknown {
+				description: "Failed to write the SVG image to the pasteboard.".into(),
 			})
 		}
 	}

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -8,10 +8,12 @@ the Apache 2.0 or the MIT license at the licensee's choice. The terms
 and conditions of the chosen license apply to this file.
 */
 
-#[cfg(feature = "image-data")]
-use crate::common::ImageData;
 use crate::common::{private, Error};
+#[cfg(feature = "image-data")]
+use crate::common::{ImageData, ImageRgba};
 use std::{borrow::Cow, marker::PhantomData, thread, time::Duration};
+
+const CFSTR_MIME_SVG_XML: &str = "image/svg+xml";
 
 #[cfg(feature = "image-data")]
 mod image_data {
@@ -54,7 +56,7 @@ mod image_data {
 
 	pub(super) fn add_cf_dibv5(
 		_open_clipboard: OpenClipboard,
-		image: ImageData,
+		image: ImageRgba,
 	) -> Result<(), Error> {
 		// This constant is missing in windows-rs
 		// https://github.com/microsoft/windows-rs/issues/2711
@@ -127,7 +129,7 @@ mod image_data {
 		}
 	}
 
-	pub(super) fn add_png_file(image: &ImageData) -> Result<(), Error> {
+	pub(super) fn add_png_file(image: &ImageRgba) -> Result<(), Error> {
 		// Try encoding the image as PNG.
 		let mut buf = Vec::new();
 		let encoder = PngEncoder::new(&mut buf);
@@ -250,11 +252,7 @@ mod image_data {
 
 			let result_bytes = win_to_rgba(&mut result_bytes);
 
-			let result = ImageData {
-				bytes: Cow::Owned(result_bytes),
-				width: w as usize,
-				height: h as usize,
-			};
+			let result = ImageData::rgba(w as _, h as _, Cow::Owned(result_bytes));
 			Ok(result)
 		}
 	}
@@ -343,7 +341,7 @@ mod image_data {
 	}
 
 	/// Vertically flips the image pixels in memory
-	fn flip_v(image: ImageData) -> ImageData<'static> {
+	fn flip_v(image: ImageRgba) -> ImageRgba<'static> {
 		let w = image.width;
 		let h = image.height;
 
@@ -365,7 +363,7 @@ mod image_data {
 			bytes[b_byte_start..b_byte_end].copy_from_slice(&tmp_a);
 		}
 
-		ImageData { width: image.width, height: image.height, bytes: bytes.into() }
+		ImageRgba { width: image.width, height: image.height, bytes: bytes.into() }
 	}
 
 	/// Converts the ARGB (u32) pixel data into the RGBA (u8) format in-place
@@ -569,9 +567,17 @@ impl<'clipboard> Get<'clipboard> {
 
 	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self) -> Result<ImageData<'static>, Error> {
-		const FORMAT: u32 = clipboard_win::formats::CF_DIBV5;
-
 		let _clipboard_assertion = self.clipboard?;
+
+		match Self::image_dibv5() {
+			Err(Error::ContentNotAvailable) => Self::image_svg(),
+			result => result,
+		}
+	}
+
+	#[cfg(feature = "image-data")]
+	fn image_dibv5() -> Result<ImageData<'static>, Error> {
+		const FORMAT: u32 = clipboard_win::formats::CF_DIBV5;
 
 		if !clipboard_win::is_format_avail(FORMAT) {
 			return Err(Error::ContentNotAvailable);
@@ -583,6 +589,23 @@ impl<'clipboard> Get<'clipboard> {
 			.map_err(|_| Error::unknown("failed to read clipboard image data"))?;
 
 		image_data::read_cf_dibv5(&data)
+	}
+
+	#[cfg(feature = "image-data")]
+	fn image_svg() -> Result<ImageData<'static>, Error> {
+		if let Some(format) = clipboard_win::register_format(CFSTR_MIME_SVG_XML) {
+			let format = format.get();
+			if !clipboard_win::is_format_avail(format) {
+				return Err(Error::ContentNotAvailable);
+			}
+
+			let mut data = Vec::new();
+			clipboard_win::raw::get_vec(format, &mut data)
+				.map_err(|_| Error::unknown("failed to read clipboard image data"))?;
+			Ok(ImageData::Svg(String::from_utf8_lossy(&data).into_owned()))
+		} else {
+			Err(Error::ContentNotAvailable)
+		}
 	}
 }
 
@@ -651,11 +674,33 @@ impl<'clipboard> Set<'clipboard> {
 			)));
 		};
 
+		match image {
+			ImageData::Rgba(image) => Self::image_rgba(open_clipboard, image),
+			ImageData::Svg(svg) => Self::image_svg(svg),
+		}
+	}
+
+	#[cfg(feature = "image-data")]
+	fn image_rgba(
+		open_clipboard: OpenClipboard<'clipboard>,
+		image: ImageRgba,
+	) -> Result<(), Error> {
 		// XXX: The ordering of these functions is important, as some programs will grab the
 		// first format available. PNGs tend to have better compatibility on Windows, so it is set first.
 		image_data::add_png_file(&image)?;
 		image_data::add_cf_dibv5(open_clipboard, image)?;
 		Ok(())
+	}
+
+	#[cfg(feature = "image-data")]
+	fn image_svg(svg: String) -> Result<(), Error> {
+		if let Some(format) = clipboard_win::register_format(CFSTR_MIME_SVG_XML) {
+			clipboard_win::raw::set(format.get(), svg.as_bytes())
+				.map_err(|_| Error::unknown("Failed to set SVG data to clipboard"))?;
+			Ok(())
+		} else {
+			Err(Error::unknown("Failed to register SVG format"))
+		}
 	}
 }
 


### PR DESCRIPTION
### Preview

Simple test


https://github.com/rustdesk-org/arboard/assets/13586388/d3a69ed9-aff0-4a81-8003-d9efea6428d3


In RustDesk (Win -> Wayland)

https://github.com/rustdesk-org/arboard/assets/13586388/3c3d5e88-8913-427b-bcac-72915967a570


### Desc

1. Introduce `resvg` to parse and convert svg to rgba.  
2. Get and set svg.

**Note:**
1. Settings svg will also set rgba image to the clipboard.
2. Parsing svg may fail.  https://github.com/RazrFalcon/resvg/issues/192#issuecomment-569467534  
Shall we add a workaround? By adding `xmlns="http://www.w3.org/2000/svg"` if it is not found.

### TODOs

1. Fix clipboard on Wayland. Both text and image.

https://github.com/rustdesk-org/arboard/assets/13586388/f8fefbcb-4b9f-4211-83ee-54abab190ba8


2. Add `get_html`.
