### PR TITLE
feat: wayland png

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,14 @@ edition = "2021"
 rust-version = "1.67.1"
 
 [features]
-default = ["image-data"]
-image-data = ["core-graphics", "image", "windows-sys"]
+default = []
 wayland-data-control = ["wl-clipboard-rs"]
 
 [dev-dependencies]
 env_logger = "0.9.0"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.48.0", optional = true, features = [
+windows-sys = { version = "0.48.0", features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_System_DataExchange",
@@ -27,29 +26,27 @@ windows-sys = { version = "0.48.0", optional = true, features = [
     "Win32_System_Ole",
 ]}
 clipboard-win = "5.4.0"
-image = { version = "0.25", optional = true, default-features = false, features = ["png"] }
+image = { version = "0.25", default-features = false, features = ["png"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Use `relax-void-encoding`, as that allows us to pass `c_void` instead of implementing `Encode` correctly for `&CGImageRef`
 objc2 = { version = "0.5.1", features = ["relax-void-encoding"] }
 objc2-foundation = { version = "0.2.0", features = ["NSArray", "NSString", "NSEnumerator", "NSGeometry"] }
 objc2-app-kit = { version = "0.2.0", features = ["NSPasteboard", "NSPasteboardItem", "NSImage"] }
-core-graphics = { version = "0.23", optional = true }
-image = { version = "0.25", optional = true, default-features = false, features = ["tiff"] }
+core-graphics = { version = "0.23" }
+image = { version = "0.25", default-features = false, features = ["tiff"] }
 
 [target.'cfg(all(unix, not(any(target_os="macos", target_os="android", target_os="emscripten"))))'.dependencies]
 x11rb = { version = "0.13" }
 wl-clipboard-rs = { version = "0.9", optional = true }
-image = { version = "0.25", optional = true, default-features = false, features = ["png"] }
+image = { version = "0.25", default-features = false, features = ["png"] }
 parking_lot = "0.12"
 
 [[example]]
 name = "get_image"
-required-features = ["image-data"]
 
 [[example]]
 name = "set_image"
-required-features = ["image-data"]
 
 [dependencies]
 log = "0.4"

--- a/examples/get_formats.rs
+++ b/examples/get_formats.rs
@@ -11,11 +11,8 @@ fn main() {
 		ClipboardFormat::Text,
 		ClipboardFormat::Html,
 		ClipboardFormat::Rtf,
-		#[cfg(feature = "image-data")]
 		ClipboardFormat::ImageRgba,
-		#[cfg(feature = "image-data")]
 		ClipboardFormat::ImagePng,
-		#[cfg(feature = "image-data")]
 		ClipboardFormat::ImageSvg,
 		ClipboardFormat::Special(FORMAT_SPECIAL),
 	];

--- a/examples/hello_formats.rs
+++ b/examples/hello_formats.rs
@@ -46,6 +46,21 @@ fn main() {
 		),
 		#[cfg(feature = "image-data")]
 		(
+			ClipboardFormat::ImagePng,
+			ClipboardData::Image(arboard::ImageData::png(
+				[
+					137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 2, 0, 0,
+					0, 2, 8, 6, 0, 0, 0, 114, 182, 13, 36, 0, 0, 0, 29, 73, 68, 65, 84, 120, 1, 1,
+					18, 0, 237, 255, 0, 255, 100, 100, 255, 100, 255, 100, 100, 0, 100, 100, 255,
+					100, 0, 0, 0, 255, 83, 20, 8, 28, 106, 36, 154, 137, 0, 0, 0, 0, 73, 69, 78,
+					68, 174, 66, 96, 130,
+				]
+				.as_ref()
+				.into(),
+			)),
+		),
+		#[cfg(feature = "image-data")]
+		(
 			ClipboardFormat::ImageSvg,
 			ClipboardData::Image(arboard::ImageData::svg(
 				r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>

--- a/examples/hello_formats.rs
+++ b/examples/hello_formats.rs
@@ -33,7 +33,6 @@ fn main() {
 		(ClipboardFormat::Text, ClipboardData::Text("Hello, world!".to_string())),
 		(ClipboardFormat::Html, ClipboardData::Html("<b>Hello, world!</b>".to_string())),
 		(ClipboardFormat::Rtf, ClipboardData::Rtf("{\\rtf1\\ansi\\b Hello, world!}".to_string())),
-		#[cfg(feature = "image-data")]
 		(
 			ClipboardFormat::ImageRgba,
 			ClipboardData::Image(arboard::ImageData::rgba(
@@ -44,7 +43,6 @@ fn main() {
 					.into(),
 			)),
 		),
-		#[cfg(feature = "image-data")]
 		(
 			ClipboardFormat::ImagePng,
 			ClipboardData::Image(arboard::ImageData::png(
@@ -59,7 +57,6 @@ fn main() {
 				.into(),
 			)),
 		),
-		#[cfg(feature = "image-data")]
 		(
 			ClipboardFormat::ImageSvg,
 			ClipboardData::Image(arboard::ImageData::svg(

--- a/src/common.rs
+++ b/src/common.rs
@@ -8,7 +8,6 @@ the Apache 2.0 or the MIT license at the licensee's choice. The terms
 and conditions of the chosen license apply to this file.
 */
 
-#[cfg(feature = "image-data")]
 use std::borrow::Cow;
 
 /// An error that might happen during a clipboard operation.
@@ -101,11 +100,8 @@ pub enum ClipboardFormat<'a> {
 	Text,
 	Html,
 	Rtf,
-	#[cfg(feature = "image-data")]
 	ImageRgba,
-	#[cfg(feature = "image-data")]
 	ImagePng,
-	#[cfg(feature = "image-data")]
 	ImageSvg,
 	Special(&'a str),
 }
@@ -116,13 +112,11 @@ pub enum ClipboardData {
 	Text(String),
 	Html(String),
 	Rtf(String),
-	#[cfg(feature = "image-data")]
 	Image(ImageData<'static>),
 	Special((String, Vec<u8>)),
 	None,
 }
 
-#[cfg(feature = "image-data")]
 #[derive(Debug, Clone)]
 pub enum ImageData<'a> {
 	Rgba(ImageRgba<'a>),
@@ -157,7 +151,6 @@ pub enum ImageData<'a> {
 ///     bytes: Cow::from(bytes.as_ref())
 /// };
 /// ```
-#[cfg(feature = "image-data")]
 #[derive(Debug, Clone)]
 pub struct ImageRgba<'a> {
 	pub width: usize,
@@ -165,7 +158,6 @@ pub struct ImageRgba<'a> {
 	pub bytes: Cow<'a, [u8]>,
 }
 
-#[cfg(feature = "image-data")]
 impl<'a> ImageData<'a> {
 	pub fn rgba(width: usize, height: usize, bytes: Cow<'a, [u8]>) -> Self {
 		ImageData::Rgba(ImageRgba { width, height, bytes })
@@ -217,7 +209,6 @@ impl<'a> ImageData<'a> {
 	}
 }
 
-#[cfg(feature = "image-data")]
 impl<'a> ImageRgba<'a> {
 	/// Returns a the bytes field in a way that it's guaranteed to be owned.
 	/// It moves the bytes if they are already owned and clones them if they are borrowed.
@@ -243,7 +234,7 @@ pub(crate) struct ScopeGuard<F: FnOnce()> {
 
 #[cfg(any(windows, all(unix, not(target_os = "macos"))))]
 impl<F: FnOnce()> ScopeGuard<F> {
-	#[cfg_attr(all(windows, not(feature = "image-data")), allow(dead_code))]
+	#[cfg_attr(windows, allow(dead_code))]
 	pub(crate) fn new(callback: F) -> Self {
 		ScopeGuard { callback: Some(callback) }
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ mod common;
 use std::borrow::Cow;
 
 pub use common::{ClipboardData, ClipboardFormat, Error};
-#[cfg(feature = "image-data")]
 pub use common::{ImageData, ImageRgba};
 
 mod platform;
@@ -146,7 +145,6 @@ impl Clipboard {
 	///
 	/// Returns error if clipboard is empty, contents are not an image, or the contents cannot be
 	/// converted to an appropriate format and stored in the [`ImageData`] type.
-	#[cfg(feature = "image-data")]
 	pub fn get_image(&mut self) -> Result<ImageData<'static>, Error> {
 		self.get().image()
 	}
@@ -163,7 +161,6 @@ impl Clipboard {
 	///
 	/// Returns error if `image` cannot be converted to an appropriate format or if it failed to be
 	/// stored on the clipboard.
-	#[cfg(feature = "image-data")]
 	pub fn set_image(&mut self, image: ImageData) -> Result<(), Error> {
 		self.set().image(image)
 	}
@@ -241,7 +238,6 @@ impl Get<'_> {
 	/// Any image data placed on the clipboard with `set_image` will be possible read back, using
 	/// this function. However it's of not guaranteed that an image placed on the clipboard by any
 	/// other application will be of a supported format.
-	#[cfg(feature = "image-data")]
 	pub fn image(self) -> Result<ImageData<'static>, Error> {
 		self.platform.image()
 	}
@@ -297,7 +293,6 @@ impl Set<'_> {
 	/// - On macOS: `NSImage` object
 	/// - On Linux: PNG, under the atom `image/png`
 	/// - On Windows: In order of priority `CF_DIB` and `CF_BITMAP`
-	#[cfg(feature = "image-data")]
 	pub fn image(self, image: ImageData) -> Result<(), Error> {
 		self.platform.image(image)
 	}
@@ -398,7 +393,6 @@ mod tests {
 			ctx.set_html(html, Some(alt_text)).unwrap();
 			assert_eq!(ctx.get_text().unwrap(), alt_text);
 		}
-		#[cfg(feature = "image-data")]
 		{
 			let mut ctx = Clipboard::new().unwrap();
 			#[rustfmt::skip]

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -38,6 +38,18 @@ fn encode_as_png(image: &ImageRgba) -> Result<Vec<u8>, Error> {
 	Ok(png_bytes)
 }
 
+#[cfg(feature = "image-data")]
+pub(crate) fn decode_from_png(bytes: Vec<u8>) -> Result<ImageRgba<'static>, Error> {
+	let img = match image::load_from_memory(&bytes) {
+		Ok(img) => img,
+		Err(_) => return Err(Error::ConversionFailure),
+	};
+	let rgba = img.to_rgba8();
+	let (width, height) = rgba.dimensions();
+	let bytes = rgba.into_raw();
+	Ok(ImageRgba { bytes: bytes.into(), width: width as _, height: height as _ })
+}
+
 /// Clipboard selection
 ///
 /// Linux has a concept of clipboard "selections" which tend to be used in different contexts. This
@@ -383,5 +395,26 @@ pub trait ClearExtLinux: private::Sealed {
 impl ClearExtLinux for crate::Clear<'_> {
 	fn clipboard(self, selection: LinuxClipboardKind) -> Result<(), Error> {
 		self.platform.clear_inner(selection)
+	}
+}
+
+mod tests {
+	#[test]
+	fn test_png_rgba_convertion() {
+		use super::{decode_from_png, encode_as_png};
+
+		let rgba_bytes =
+			[255u8, 100, 100, 255, 100, 255, 100, 100, 100, 100, 255, 100, 0, 0, 0, 255];
+		let w1 = 2;
+		let h1 = 2;
+
+		let img_rgba =
+			crate::ImageRgba { bytes: rgba_bytes.clone().to_vec().into(), width: w1, height: h1 };
+		let png_bytes = encode_as_png(&img_rgba).unwrap();
+		let img_rgba2 = decode_from_png(png_bytes).unwrap();
+
+		assert_eq!(rgba_bytes.to_vec(), img_rgba2.bytes.to_vec());
+		assert_eq!(w1, img_rgba2.width);
+		assert_eq!(h1, img_rgba2.height);
 	}
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -4,7 +4,6 @@ use std::{borrow::Cow, time::Instant};
 use log::{trace, warn};
 
 use crate::{common::private, ClipboardData, ClipboardFormat, Error};
-#[cfg(feature = "image-data")]
 use crate::{ImageData, ImageRgba};
 
 mod x11;
@@ -16,7 +15,6 @@ fn into_unknown<E: std::fmt::Display>(error: E) -> Error {
 	Error::Unknown { description: error.to_string() }
 }
 
-#[cfg(feature = "image-data")]
 fn encode_as_png(image: &ImageRgba) -> Result<Vec<u8>, Error> {
 	use image::ImageEncoder as _;
 
@@ -38,7 +36,6 @@ fn encode_as_png(image: &ImageRgba) -> Result<Vec<u8>, Error> {
 	Ok(png_bytes)
 }
 
-#[cfg(feature = "image-data")]
 pub(crate) fn decode_from_png(bytes: Vec<u8>) -> Result<ImageRgba<'static>, Error> {
 	let img = match image::load_from_memory(&bytes) {
 		Ok(img) => img,
@@ -142,7 +139,6 @@ impl<'clipboard> Get<'clipboard> {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self) -> Result<ImageData<'static>, Error> {
 		match self.clipboard {
 			Clipboard::X11(clipboard) => clipboard.get_image(self.selection),
@@ -236,7 +232,6 @@ impl<'clipboard> Set<'clipboard> {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self, image: ImageData<'_>) -> Result<(), Error> {
 		match self.clipboard {
 			Clipboard::X11(clipboard) => clipboard.set_image(image, self.selection, self.wait),

--- a/src/platform/linux/wayland.rs
+++ b/src/platform/linux/wayland.rs
@@ -7,16 +7,12 @@ use wl_clipboard_rs::{
 	utils::is_primary_selection_supported,
 };
 
-#[cfg(feature = "image-data")]
 use super::encode_as_png;
 use super::{into_unknown, LinuxClipboardKind, WaitConfig};
 use crate::common::{ClipboardData, ClipboardFormat, Error};
-#[cfg(feature = "image-data")]
 use crate::common::{ImageData, ImageRgba};
 
-#[cfg(feature = "image-data")]
 const MIME_PNG: &str = "image/png";
-#[cfg(feature = "image-data")]
 const MIME_SVG: &str = "image/svg+xml";
 const MIME_HTML: &'static str = "text/html";
 const MIME_RTF: &'static str = "text/rtf";
@@ -179,7 +175,6 @@ impl Clipboard {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn get_image(
 		&mut self,
 		selection: LinuxClipboardKind,
@@ -190,7 +185,6 @@ impl Clipboard {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn get_image_rgba(
 		&mut self,
 		selection: LinuxClipboardKind,
@@ -215,7 +209,6 @@ impl Clipboard {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn get_image_png(
 		&mut self,
 		selection: LinuxClipboardKind,
@@ -239,7 +232,6 @@ impl Clipboard {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn get_image_svg(
 		&mut self,
 		selection: LinuxClipboardKind,
@@ -263,7 +255,6 @@ impl Clipboard {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn set_image(
 		&mut self,
 		image: ImageData,
@@ -277,7 +268,6 @@ impl Clipboard {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn set_image_rgba(
 		&mut self,
 		image: ImageRgba,
@@ -288,7 +278,6 @@ impl Clipboard {
 		self.set_source(Self::png_to_mime_source(image), selection, wait)
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn set_image_png(
 		&mut self,
 		png: Vec<u8>,
@@ -298,7 +287,6 @@ impl Clipboard {
 		self.set_source(Self::png_to_mime_source(png), selection, wait)
 	}
 
-	#[cfg(feature = "image-data")]
 	fn png_to_mime_source(png: Vec<u8>) -> MimeSource {
 		MimeSource {
 			source: Source::Bytes(png.into_boxed_slice()),
@@ -306,7 +294,6 @@ impl Clipboard {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn set_image_svg(
 		&mut self,
 		svg: String,
@@ -316,7 +303,6 @@ impl Clipboard {
 		self.set_source(Self::svg_to_mime_source(svg), selection, wait)
 	}
 
-	#[cfg(feature = "image-data")]
 	fn svg_to_mime_source(svg: String) -> MimeSource {
 		MimeSource {
 			source: Source::Bytes(svg.into_bytes().into_boxed_slice()),
@@ -388,19 +374,16 @@ impl Clipboard {
 					Err(Error::ContentNotAvailable) => results.push(ClipboardData::None),
 					Err(e) => return Err(e),
 				},
-				#[cfg(feature = "image-data")]
 				ClipboardFormat::ImageRgba => match self.get_image_rgba(selection) {
 					Ok(image) => results.push(ClipboardData::Image(image)),
 					Err(Error::ContentNotAvailable) => results.push(ClipboardData::None),
 					Err(e) => return Err(e),
 				},
-				#[cfg(feature = "image-data")]
 				ClipboardFormat::ImagePng => match self.get_image_png(selection) {
 					Ok(image) => results.push(ClipboardData::Image(image)),
 					Err(Error::ContentNotAvailable) => results.push(ClipboardData::None),
 					Err(e) => return Err(e),
 				},
-				#[cfg(feature = "image-data")]
 				ClipboardFormat::ImageSvg => match self.get_image_svg(selection) {
 					Ok(image) => results.push(ClipboardData::Image(image)),
 					Err(Error::ContentNotAvailable) => results.push(ClipboardData::None),
@@ -438,7 +421,6 @@ impl Clipboard {
 				ClipboardData::Html(html) => {
 					sources.push(Self::html_to_mime_source(Cow::Borrowed(html)));
 				}
-				#[cfg(feature = "image-data")]
 				ClipboardData::Image(image) => match image {
 					ImageData::Rgba(image) => {
 						sources.push(Self::png_to_mime_source(encode_as_png(image)?));

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -956,17 +956,8 @@ impl Clipboard {
 	) -> Result<ImageData<'static>> {
 		let formats = [self.inner.atoms.PNG_MIME];
 		let bytes = self.inner.read(&formats, selection)?.bytes;
-
-		let cursor = std::io::Cursor::new(&bytes);
-		let mut reader = image::io::Reader::new(cursor);
-		reader.set_format(image::ImageFormat::Png);
-		let image = match reader.decode() {
-			Ok(img) => img.into_rgba8(),
-			Err(_e) => return Err(Error::ConversionFailure),
-		};
-		let (w, h) = image.dimensions();
-		let image_data = ImageData::rgba(w as _, h as _, image.into_raw().into());
-		Ok(image_data)
+		let image_data = super::decode_from_png(bytes)?;
+		Ok(ImageData::Rgba(image_data))
 	}
 
 	#[cfg(feature = "image-data")]

--- a/src/platform/linux/x11.rs
+++ b/src/platform/linux/x11.rs
@@ -43,11 +43,9 @@ use x11rb::{
 	COPY_DEPTH_FROM_PARENT, COPY_FROM_PARENT, NONE,
 };
 
-#[cfg(feature = "image-data")]
 use super::encode_as_png;
 use super::{into_unknown, LinuxClipboardKind, WaitConfig};
 use crate::{common::ScopeGuard, ClipboardData, ClipboardFormat, Error};
-#[cfg(feature = "image-data")]
 use crate::{ImageData, ImageRgba};
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -938,7 +936,6 @@ impl Clipboard {
 		ClipboardDataX11 { bytes: html.into_owned().into_bytes(), format: self.inner.atoms.HTML }
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn get_image(&self, selection: LinuxClipboardKind) -> Result<ImageData<'static>> {
 		let formats = [self.inner.atoms.SVG_MIME, self.inner.atoms.PNG_MIME];
 		let result = self.inner.read(&formats, selection)?;
@@ -949,7 +946,6 @@ impl Clipboard {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn get_image_rgba(
 		&self,
 		selection: LinuxClipboardKind,
@@ -960,7 +956,6 @@ impl Clipboard {
 		Ok(ImageData::Rgba(image_data))
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn get_image_png(
 		&self,
 		selection: LinuxClipboardKind,
@@ -970,7 +965,6 @@ impl Clipboard {
 		Ok(ImageData::png(bytes.into()))
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn get_image_svg(
 		&self,
 		selection: LinuxClipboardKind,
@@ -981,7 +975,6 @@ impl Clipboard {
 		Ok(ImageData::svg(svg))
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn set_image(
 		&self,
 		image: ImageData,
@@ -995,7 +988,6 @@ impl Clipboard {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn set_image_rgba(
 		&self,
 		image: ImageRgba,
@@ -1006,13 +998,11 @@ impl Clipboard {
 		self.inner.write(data, selection, wait)
 	}
 
-	#[cfg(feature = "image-data")]
 	fn rgba_to_clip_data(&self, image: ImageRgba) -> Result<ClipboardDataX11> {
 		let encoded = encode_as_png(&image)?;
 		Ok(ClipboardDataX11 { bytes: encoded, format: self.inner.atoms.PNG_MIME })
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn set_image_png(
 		&self,
 		png: Vec<u8>,
@@ -1023,12 +1013,10 @@ impl Clipboard {
 		self.inner.write(data, selection, wait)
 	}
 
-	#[cfg(feature = "image-data")]
 	fn png_to_clip_data(&self, png: Vec<u8>) -> ClipboardDataX11 {
 		ClipboardDataX11 { bytes: png, format: self.inner.atoms.PNG_MIME }
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn set_image_svg(
 		&self,
 		svg: String,
@@ -1108,19 +1096,16 @@ impl Clipboard {
 					Err(Error::ContentNotAvailable) => results.push(ClipboardData::None),
 					Err(e) => return Err(e),
 				},
-				#[cfg(feature = "image-data")]
 				ClipboardFormat::ImageRgba => match self.get_image_rgba(selection) {
 					Ok(image) => results.push(ClipboardData::Image(image)),
 					Err(Error::ContentNotAvailable) => results.push(ClipboardData::None),
 					Err(e) => return Err(e),
 				},
-				#[cfg(feature = "image-data")]
 				ClipboardFormat::ImagePng => match self.get_image_png(selection) {
 					Ok(image) => results.push(ClipboardData::Image(image)),
 					Err(Error::ContentNotAvailable) => results.push(ClipboardData::None),
 					Err(e) => return Err(e),
 				},
-				#[cfg(feature = "image-data")]
 				ClipboardFormat::ImageSvg => match self.get_image_svg(selection) {
 					Ok(image) => results.push(ClipboardData::Image(image)),
 					Err(Error::ContentNotAvailable) => results.push(ClipboardData::None),

--- a/src/platform/osx.rs
+++ b/src/platform/osx.rs
@@ -8,7 +8,6 @@ the Apache 2.0 or the MIT license at the licensee's choice. The terms
 and conditions of the chosen license apply to this file.
 */
 
-#[cfg(feature = "image-data")]
 use crate::common::{ImageData, ImageRgba};
 use crate::{common::Error, ClipboardData, ClipboardFormat};
 use objc2::{
@@ -31,7 +30,6 @@ use std::{
 const NS_PASTEBOARD_TYPE_SVG: &str = "public.svg-image";
 
 /// Returns an NSImage object on success.
-#[cfg(feature = "image-data")]
 fn image_from_pixels(
 	pixels: Vec<u8>,
 	width: usize,
@@ -226,7 +224,6 @@ impl<'clipboard> Get<'clipboard> {
 		})
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self) -> Result<ImageData<'static>, Error> {
 		match self.image_svg() {
 			Err(Error::ContentNotAvailable) => match self.image_png() {
@@ -238,7 +235,6 @@ impl<'clipboard> Get<'clipboard> {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	fn image_tiff(&self) -> Result<ImageData<'static>, Error> {
 		use objc2_app_kit::NSPasteboardTypeTIFF;
 		use std::io::Cursor;
@@ -261,7 +257,6 @@ impl<'clipboard> Get<'clipboard> {
 		Ok(ImageData::rgba(width as _, height as _, rgba.into_raw().into()))
 	}
 
-	#[cfg(feature = "image-data")]
 	fn image_png(&self) -> Result<ImageData<'static>, Error> {
 		use objc2_app_kit::NSPasteboardTypePNG;
 		autoreleasepool(|_| {
@@ -271,7 +266,6 @@ impl<'clipboard> Get<'clipboard> {
 		})
 	}
 
-	#[cfg(feature = "image-data")]
 	fn image_svg(&self) -> Result<ImageData<'static>, Error> {
 		autoreleasepool(|_| {
 			let image_data = unsafe {
@@ -338,7 +332,6 @@ impl<'clipboard> Get<'clipboard> {
 								break;
 							}
 						}
-						#[cfg(feature = "image-data")]
 						ClipboardFormat::ImageRgba => match self.image_tiff() {
 							Ok(image) => {
 								results.push(ClipboardData::Image(image));
@@ -347,7 +340,6 @@ impl<'clipboard> Get<'clipboard> {
 							Err(Error::ContentNotAvailable) => {}
 							Err(e) => return Err(e),
 						},
-						#[cfg(feature = "image-data")]
 						ClipboardFormat::ImagePng => match self.image_png() {
 							Ok(image) => {
 								results.push(ClipboardData::Image(image));
@@ -356,7 +348,6 @@ impl<'clipboard> Get<'clipboard> {
 							Err(Error::ContentNotAvailable) => {}
 							Err(e) => return Err(e),
 						},
-						#[cfg(feature = "image-data")]
 						ClipboardFormat::ImageSvg => match self.image_svg() {
 							Ok(image) => {
 								results.push(ClipboardData::Image(image));
@@ -480,7 +471,6 @@ impl<'clipboard> Set<'clipboard> {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn image(mut self, data: ImageData) -> Result<(), Error> {
 		self.image_(data, true)
 	}
@@ -493,7 +483,6 @@ impl<'clipboard> Set<'clipboard> {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn image_pixels(&mut self, data: ImageRgba, clear: bool) -> Result<(), Error> {
 		if clear {
 			self.clipboard.clear();
@@ -516,7 +505,6 @@ impl<'clipboard> Set<'clipboard> {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn image_png(&mut self, data: &[u8], clear: bool) -> Result<(), Error> {
 		use objc2_app_kit::NSPasteboardTypePNG;
 
@@ -540,7 +528,6 @@ impl<'clipboard> Set<'clipboard> {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn image_svg(&mut self, data: String, clear: bool) -> Result<(), Error> {
 		if clear {
 			self.clipboard.clear();
@@ -592,7 +579,6 @@ impl<'clipboard> Set<'clipboard> {
 				ClipboardData::Text(data) => self.text_(Cow::Borrowed(data), false)?,
 				ClipboardData::Rtf(data) => self.rtf_(Cow::Borrowed(data), false)?,
 				ClipboardData::Html(data) => self.html_(Cow::Borrowed(data), None, false)?,
-				#[cfg(feature = "image-data")]
 				ClipboardData::Image(data) => self.image_(data.clone(), false)?,
 				ClipboardData::Special((format_name, data)) => {
 					self.special_(format_name, data, false)?

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -11,7 +11,6 @@ and conditions of the chosen license apply to this file.
 use clipboard_win::{formats::Html, options, Getter};
 use windows_sys::Win32::Foundation::ERROR_NOT_FOUND;
 
-#[cfg(feature = "image-data")]
 use crate::common::{ImageData, ImageRgba};
 use crate::{
 	common::{private, Error},
@@ -23,7 +22,6 @@ const CFSTR_MIME_RICHTEXT: &str = "text/richtext";
 const CFSTR_MIME_PNG: &str = "image/png";
 const CFSTR_MIME_SVG_XML: &str = "image/svg+xml";
 
-#[cfg(feature = "image-data")]
 mod image_data {
 	use super::*;
 	use crate::common::ScopeGuard;
@@ -619,7 +617,6 @@ impl<'clipboard> Get<'clipboard> {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self) -> Result<ImageData<'static>, Error> {
 		let _clipboard_assertion = self.clipboard?;
 		Self::image_()
@@ -635,7 +632,6 @@ impl<'clipboard> Get<'clipboard> {
 		}
 	}
 
-	#[cfg(feature = "image-data")]
 	fn image_dibv5() -> Result<ImageData<'static>, Error> {
 		const FORMAT: u32 = clipboard_win::formats::CF_DIBV5;
 
@@ -651,7 +647,6 @@ impl<'clipboard> Get<'clipboard> {
 		image_data::read_cf_dibv5(&data)
 	}
 
-	#[cfg(feature = "image-data")]
 	fn image_png() -> Result<ImageData<'static>, Error> {
 		let format = register_format_(CFSTR_MIME_PNG)?;
 		if !clipboard_win::is_format_avail(format) {
@@ -664,7 +659,6 @@ impl<'clipboard> Get<'clipboard> {
 		Ok(ImageData::png(data.into()))
 	}
 
-	#[cfg(feature = "image-data")]
 	fn image_svg() -> Result<ImageData<'static>, Error> {
 		let format = register_format_(CFSTR_MIME_SVG_XML)?;
 		if !clipboard_win::is_format_avail(format) {
@@ -715,19 +709,16 @@ impl<'clipboard> Get<'clipboard> {
 					Err(Error::ContentNotAvailable) => results.push(ClipboardData::None),
 					Err(e) => return Err(e),
 				},
-				#[cfg(feature = "image-data")]
 				ClipboardFormat::ImageRgba => match Self::image_dibv5() {
 					Ok(image) => results.push(ClipboardData::Image(image)),
 					Err(Error::ContentNotAvailable) => results.push(ClipboardData::None),
 					Err(e) => return Err(e),
 				},
-				#[cfg(feature = "image-data")]
 				ClipboardFormat::ImagePng => match Self::image_png() {
 					Ok(image) => results.push(ClipboardData::Image(image)),
 					Err(Error::ContentNotAvailable) => results.push(ClipboardData::None),
 					Err(e) => return Err(e),
 				},
-				#[cfg(feature = "image-data")]
 				ClipboardFormat::ImageSvg => match Self::image_svg() {
 					Ok(image) => results.push(ClipboardData::Image(image)),
 					Err(Error::ContentNotAvailable) => results.push(ClipboardData::None),
@@ -846,7 +837,6 @@ impl<'clipboard> Set<'clipboard> {
 			.map_err(|e| Error::unknown(e.to_string()))
 	}
 
-	#[cfg(feature = "image-data")]
 	pub(crate) fn image(self, image: ImageData) -> Result<(), Error> {
 		let _open_clipboard = self.clipboard?;
 		if let Err(e) = clipboard_win::raw::empty() {
@@ -866,7 +856,6 @@ impl<'clipboard> Set<'clipboard> {
 	}
 
 	#[inline]
-	#[cfg(feature = "image-data")]
 	fn image_rgba(image: ImageRgba) -> Result<(), Error> {
 		// XXX: The ordering of these functions is important, as some programs will grab the
 		// first format available. PNGs tend to have better compatibility on Windows, so it is set first.
@@ -875,7 +864,6 @@ impl<'clipboard> Set<'clipboard> {
 	}
 
 	#[inline]
-	#[cfg(feature = "image-data")]
 	fn image_svg(svg: String) -> Result<(), Error> {
 		let format = register_format_(CFSTR_MIME_SVG_XML)?;
 		clipboard_win::raw::set_without_clear(format, svg.as_bytes())
@@ -925,7 +913,6 @@ impl<'clipboard> Set<'clipboard> {
 				ClipboardData::Html(html) => {
 					Self::html_without_alt_(html.clone().into())?;
 				}
-				#[cfg(feature = "image-data")]
 				ClipboardData::Image(image) => {
 					Self::image_(image.clone())?;
 				}


### PR DESCRIPTION
1. Add missing png support on Wayland.
2. Extract a common function `decode_from_png()`.


